### PR TITLE
Variable bounds instead of affine constraint

### DIFF
--- a/src/decision_model.jl
+++ b/src/decision_model.jl
@@ -48,12 +48,7 @@ end
 
 function path_compatibility_variable(model::Model, base_name::String="")
     # Create a path compatiblity variable
-    x = @variable(model, base_name=base_name)
-
-    # Constraint on the lower and upper bounds.
-    @constraint(model, 0 ≤ x ≤ 1.0)
-
-    return x
+    return @variable(model, base_name=base_name, lower_bound = 0, upper_bound = 1)
 end
 
 struct PathCompatibilityVariables{N} <: AbstractDict{Path{N}, VariableRef}


### PR DESCRIPTION
`@constraint(model, 0 <= x <= 1)` is transferred to the solver as a `ScalarAffineFunction`-in-`Interval` constraint. Unless the solver has a presolve that detects that this is a variable bound, it might not see that these are variable bounds and hence this could negatively affect performance.